### PR TITLE
chore: bump version to 2.0.0-rc.3 and fix rake-compiler dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -263,7 +263,7 @@ checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
 name = "ruby_native_statistics"
-version = "2.0.0-rc.2"
+version = "2.0.0-rc.3"
 dependencies = [
  "magnus",
  "rb-sys",

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,6 @@ PATH
   remote: .
   specs:
     ruby_native_statistics (2.0.0.rc.2)
-      rake-compiler (~> 1.3)
       rb_sys (~> 0.9.91)
 
 GEM
@@ -23,6 +22,7 @@ PLATFORMS
 DEPENDENCIES
   minitest (~> 5.21)
   rake (~> 13.0)
+  rake-compiler (~> 1.3)
   ruby_native_statistics!
 
 BUNDLED WITH

--- a/README.md
+++ b/README.md
@@ -57,6 +57,10 @@ If you found a bug or need a particular function, please let me know! I work on 
     # calculate percentile
     p r.percentile(0.3333)
 
+## Build notes
+
+If you are installing the source vesion of the Gem, be sure to have libclang, e.g. `libclang-dev`, installed on your system.
+
 ## Implementation notes
 
 ### Percentile

--- a/ext/ruby_native_statistics/Cargo.toml
+++ b/ext/ruby_native_statistics/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ruby_native_statistics"
-version = "2.0.0-rc.2"
+version = "2.0.0-rc.3"
 edition = "2024"
 
 [lib]

--- a/lib/ruby_native_statistics/version.rb
+++ b/lib/ruby_native_statistics/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module RubyNativeStatistics
-  VERSION = '2.0.0.rc.2'
+  VERSION = '2.0.0.rc.3'
 end

--- a/ruby_native_statistics.gemspec
+++ b/ruby_native_statistics.gemspec
@@ -33,9 +33,9 @@ Gem::Specification.new do |spec|
   spec.platform = Gem::Platform::RUBY
   spec.required_ruby_version = '>= 3.2.8'
 
-  spec.add_dependency 'rake-compiler', '~> 1.3'
   spec.add_dependency 'rb_sys', '~> 0.9.91'
 
+  spec.add_development_dependency 'rake-compiler', '~> 1.3'
   spec.add_development_dependency "rake", "~> 13.0"
   spec.add_development_dependency 'minitest', '~> 5.21'
 


### PR DESCRIPTION
- Bump version from 2.0.0-rc.2 to 2.0.0-rc.3 in all relevant files
- Move rake-compiler from runtime to development dependency
- Add build notes about libclang requirement to README